### PR TITLE
Create missing cache directory.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,9 @@ if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   exit 1
 fi
 
+
+mkdir -p "${HOME}/.cache"
+
 eval $(/assume-role-arn $*)
 
 echo "::set-env name=AWS_ACCESS_KEY_ID::${AWS_ACCESS_KEY_ID}"


### PR DESCRIPTION
This fixes the problem where the `assume-role-arn` binary would fail to create
credentials cache inside the `${HOME}/.cache` as the directory would not exist
prior to the binary being run.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@nordcloud.com>