### PR TITLE
Update Docker container build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,90 @@
-FROM alpine:latest
-COPY LICENSE.md /
-ENV VERSION 0.3.3
-RUN apk update && apk add wget ca-certificates file && rm -rf /var/cache/apk/*   &&   update-ca-certificates 
-RUN wget https://github.com/nordcloud/assume-role-arn/releases/download/v${VERSION}/assume-role-arn-linux -O /assume-role-arn && \
-    chmod a+x /assume-role-arn
-ADD entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-WORKDIR /
-ENTRYPOINT ["/entrypoint.sh"]
+ARG alpine_version="${alpine_version:-latest}"
+
+FROM alpine:${alpine_version} AS builder
+
+ARG version="${version:-latest}"
+
+RUN set -eux && \
+    mkdir -p /build
+
+WORKDIR /build
+
+COPY . ./
+
+RUN set -eux && \
+    apk --no-cache --update add ca-certificates && \
+    apk --no-cache --update add curl && \
+    apk --no-cache --update add jq && \
+    if [ "x${version}" = 'xlatest' ]; then \
+        curl -s 'https://api.github.com/repos/nordcloud/assume-role-arn/releases/latest' | \
+            jq -r '.assets[] | select(.name | contains("linux")) | .browser_download_url' | \
+                xargs curl -L -o /build/assume-role-arn; \
+    else \
+        curl -L -o /build/assume-role-arn "https://github.com/nordcloud/assume-role-arn/releases/download/v${version}/assume-role-arn-linux"; \
+    fi;
+
+FROM alpine:${alpine_version}
+
+ARG version="${version:-latest}"
+
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.name="aws-assume-role" \
+    org.label-schema.version="${version}" \
+    org.label-schema.description="It lets you assume a role and sets the credentials accordingly." \
+    org.label-schema.license="MIT" \
+    org.label-schema.url="https://github.com/nordcloud/aws-assume-role" \
+    org.label-schema.vcs-url="https://github.com/nordcloud/aws-assume-role.git" \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vendor="Nordcloud <info@nordcloud.com> (http://www.nordcloud.com/)" \
+    version="${version}" \
+    maintainer="Dariusz Dwornikowski <dariusz.dwornikowski@nordcloud.com>" \
+    license="MIT" \
+    vendor="Open Source Software"
+
+ENV GOGC off
+
+ENV AWS_PROFILE ""
+ENV AWS_ACCESS_KEY_ID ""
+ENV AWS_SECRET_ACCESS_KEY ""
+
+ENV ROLE_ARN ""
+ENV ROLE_SESSION_NAME ""
+ENV EXTERNAL_ID ""
+
+ENV VERBOSE false
+
+ENV DEBUG false
+
+WORKDIR /tmp
+
+RUN set -eux && \
+    apk --no-cache --update add ca-certificates && \
+    rm -Rf /var/lib/apt/lists/* && \
+    rm -Rf /var/cache/apk/* && \
+    rm -Rf /tmp/* && \
+    rm -Rf /var/tmp/*
+
+COPY --from=builder \
+    /build/assume-role-arn \
+    /build/assume-role-arn.sh \
+    /usr/local/bin/
+
+COPY --from=builder \
+    /build/docker-entrypoint.sh /docker-entrypoint.sh
+
+RUN set -eux && \
+    mkdir -p /docker-entrypoint.d && \
+    chmod 755 /usr/local/bin/assume-role-arn && \
+    chmod 755 /usr/local/bin/assume-role-arn.sh && \
+    chmod 755 /docker-entrypoint.sh
+
+COPY --from=builder \
+    /build/docker-entrypoint.d/* /docker-entrypoint.d/
+
+RUN set -eux && \
+    chmod 755 /docker-entrypoint.d/*
+
+STOPSIGNAL SIGKILL
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/assume-role-arn.sh
+++ b/assume-role-arn.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+if [ "x$DEBUG" = 'xtrue' ]; then
+    set -x && VERBOSE='true'
+fi
+
+export PATH='/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+
+ASSUME_ROLE_ARN='assume-role-arn'
+
+if [ "x$AWS_PROFILE" = 'xtrue' ]; then
+    ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -p $AWS_PROFILE"
+fi
+
+if [ "x$ROLE_ARN" = 'xtrue' ]; then
+    ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -r $ROLE_ARN"
+fi
+
+if [ "x$ROLE_SESSION_NAME" != 'x' ]; then
+    ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -n $ROLE_SESSION_NAME"
+fi
+
+if [ "x$EXTERNAL_ID" != 'x' ]; then
+    ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -e $EXTERNAL_ID"
+fi
+
+if [ "x$VERBOSE" = 'xtrue' ]; then
+    ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -v"
+fi
+
+ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN $*"
+set -- "$ASSUME_ROLE_ARN"
+
+eval "$ASSUME_ROLE_ARN"
+
+echo "::set-env name=AWS_ACCESS_KEY_ID::${AWS_ACCESS_KEY_ID}"
+echo "::set-env name=AWS_SECRET_ACCESS_KEY::${AWS_SECRET_ACCESS_KEY}"
+echo "::set-env name=AWS_SESSION_TOKEN::${AWS_SESSION_TOKEN}"

--- a/docker-entrypoint.d/001-verify-aws-credentials.sh
+++ b/docker-entrypoint.d/001-verify-aws-credentials.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+if [ "x$DEBUG" = 'xtrue' ]; then
+    set -x
+fi
+
+if [ "x$CHECK_ENVIRONMENT" = 'xfalse' ]; then
+    echo 'Environment variables check has been disabled.'
+    exit 0
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "The 'AWS_ACCESS_KEY_ID' environment variable has to be set, aborting..."
+    exit 1
+fi
+
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "The 'AWS_SECRET_ACCESS_KEY' environment variable has to be set, aborting..."
+    exit 1
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+if [ "x$DEBUG" = 'xtrue' ]; then
+    set -x
+fi
+
+export PATH='/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+
+DIRECTORY='/docker-entrypoint.d'
+
+if [ -d $DIRECTORY ] && [ -n "$(ls -A $DIRECTORY)" ]; then
+    for file in ${DIRECTORY}/*; do
+        case "$file" in
+            *.sh)
+                if [ -x "$file" ]; then
+                    echo "$0: RUNNING: $file"
+                    "$file"
+                else
+                    echo "$0: SOURCING: $file"
+                    . "$file"
+                fi
+                ;;
+            *) echo "$0: IGNORING: $file" ;;
+        esac
+        echo
+    done
+fi
+
+if [ ! -d "${HOME}/.cache" ]; then
+    mkdir -p "${HOME}/.cache"
+    chmod u+rwx,g=,o= "${HOME}/.cache"
+fi
+
+if [ "${1#-}" != "$1" ]; then
+    set -- assume-role-arn.sh "$@"
+else
+    set -- assume-role-arn.sh
+fi
+
+exec "$@"


### PR DESCRIPTION
Move Docker container build to a multi-stage to enable support for downloading
latest release of the `assume-role-arn` project binaries.  Add Docker container
metadata via labels.  Update names of the environment variables to match the
AWS' terminology more closely.  Add support for the `docker-entrypoint.d`
directory.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@nordcloud.com>