### PR TITLE
Fix command-line switches assemble using environment variables.

### DIFF
--- a/assume-role-arn.sh
+++ b/assume-role-arn.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -e
-if [ "x$DEBUG" = 'xtrue' ]; then
+if [ "x${DEBUG}" = 'xtrue' ]; then
     set -x && VERBOSE='true'
 fi
 
@@ -9,27 +9,27 @@ export PATH='/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
 
 ASSUME_ROLE_ARN='assume-role-arn'
 
-if [ "x$AWS_PROFILE" = 'xtrue' ]; then
+if [ "x${AWS_PROFILE}" != 'x' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -p $AWS_PROFILE"
 fi
 
-if [ "x$ROLE_ARN" = 'xtrue' ]; then
+if [ "x${ROLE_ARN}" != 'x' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -r $ROLE_ARN"
 fi
 
-if [ "x$ROLE_SESSION_NAME" != 'x' ]; then
+if [ "x${ROLE_SESSION_NAME}" != 'x' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -n $ROLE_SESSION_NAME"
 fi
 
-if [ "x$EXTERNAL_ID" != 'x' ]; then
+if [ "x${EXTERNAL_ID}" != 'x' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -e $EXTERNAL_ID"
 fi
 
-if [ "x$SKIP_CACHE" = 'xtrue' ]; then
+if [ "x${SKIP_CACHE}" = 'xtrue' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -skipCache"
 fi
 
-if [ "x$VERBOSE" = 'xtrue' ]; then
+if [ "x${VERBOSE}" = 'xtrue' ]; then
     ASSUME_ROLE_ARN="$ASSUME_ROLE_ARN -v"
 fi
 

--- a/docker-entrypoint.d/001-verify-aws-credentials.sh
+++ b/docker-entrypoint.d/001-verify-aws-credentials.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 set -e
-if [ "x$DEBUG" = 'xtrue' ]; then
+if [ "x${DEBUG}" = 'xtrue' ]; then
     set -x
 fi
 
-if [ "x$CHECK_ENVIRONMENT" = 'xfalse' ]; then
+if [ "x${CHECK_ENVIRONMENT}" = 'xfalse' ]; then
     echo 'Environment variables check has been disabled.'
     exit 0
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -e
-if [ "x$DEBUG" = 'xtrue' ]; then
+if [ "x${DEBUG}" = 'xtrue' ]; then
     set -x
 fi
 


### PR DESCRIPTION
This change ixes a bug related to testing environment variables when
assembling command-line switches that will passed to `assume-role-arn`.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@nordcloud.com>